### PR TITLE
Automatically install the latest GA Shell

### DIFF
--- a/Formula/mongodb-community-shell.rb
+++ b/Formula/mongodb-community-shell.rb
@@ -1,8 +1,30 @@
 class MongodbCommunityShell < Formula
   desc "An interactive JavaScript command-line interface to MongoDB"
   homepage "https://www.mongodb.com/"
-  url "https://fastdl.mongodb.org/osx/mongodb-shell-osx-ssl-x86_64-4.0.6.tgz"
-  sha256 "bcc6c3da65dcdb62b09b044a7f578e0caada5ac1051f6ef41456bc517a542b6a"
+
+  # frozen_string_literal: true
+
+  require 'net/http'
+  require 'json'
+  current = JSON.parse(Net::HTTP.get(URI('http://downloads.mongodb.org/current.json')))
+  latest_ga = current['versions'].select { |r|
+    r['production_release'] == true
+  } .max_by { |v|
+    Gem::Version.new(v['version'])
+  }
+  latest_ga_ver = latest_ga['version']
+  dl_prefix = 'https://fastdl.mongodb.org/osx/mongodb-shell'
+  dl_platform = if Gem::Version.new(latest_ga_ver) < Gem::Version.new('4.2.0')
+                  'osx-ssl-x86_64'
+                else
+                  'macos-x86_64'
+                end
+  dl_url = "#{dl_prefix}-#{dl_platform}-#{latest_ga_ver}.tgz"
+  dl_sha256 = Net::HTTP.get(URI("#{dl_url}.sha256"))
+                       .strip.split(' ')[0]
+
+  url dl_url
+  sha256 dl_sha256
 
   bottle :unneeded
 


### PR DESCRIPTION
While the package is not available in the release stream, we're able to utilize the stream in order to determine the latest GA version and then construct the download artifact URLs from there. 