### PR TITLE
Automatically grab the latest patch releases for 3.x

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -19,8 +19,8 @@ class MongodbCommunity < Formula
     a['archive']
   }[0]
 
-  url latest_mac["url"]
-  sha256 latest_mac["sha256"]
+  url latest_mac['url']
+  sha256 latest_mac['sha256']
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@3.2.rb
+++ b/Formula/mongodb-community@3.2.rb
@@ -1,8 +1,25 @@
 class MongodbCommunityAT32 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
-  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.2.22.tgz"
-  sha256 "0f85d6e1810993cf3c02216a8b8abe20c0cde3d1fb6a9ac445ca26819f3cc2c9"
+
+  # frozen_string_literal: true
+
+  require 'net/http'
+  require 'json'
+  current = JSON.parse(Net::HTTP.get(URI('http://downloads.mongodb.org/current.json')))
+  latest = current['versions'].select { |r|
+    r['production_release'] == true \
+    && r['version'] =~ /^3\.2\.[0-9]+$/
+  }[0]
+  latest_mac = latest['downloads'].select { |m|
+    (m['target'] == 'osx-ssl' || m['target'] == 'macos') \
+    && m['edition'] == 'base'
+  } .map { |a|
+    a['archive']
+  }[0]
+
+  url latest_mac['url']
+  sha256 latest_mac['sha256']
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@3.4.rb
+++ b/Formula/mongodb-community@3.4.rb
@@ -1,8 +1,25 @@
 class MongodbCommunityAT34 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
-  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.4.19.tgz"
-  sha256 "bd1b8cd6adb19ecdb533c1fe64bea49631915fe57334eb49abc661fcb549c0cf"
+
+  # frozen_string_literal: true
+
+  require 'net/http'
+  require 'json'
+  current = JSON.parse(Net::HTTP.get(URI('http://downloads.mongodb.org/current.json')))
+  latest = current['versions'].select { |r|
+    r['production_release'] == true \
+    && r['version'] =~ /^3\.4\.[0-9]+$/
+  }[0]
+  latest_mac = latest['downloads'].select { |m|
+    (m['target'] == 'osx-ssl' || m['target'] == 'macos') \
+    && m['edition'] == 'base'
+  } .map { |a|
+    a['archive']
+  }[0]
+
+  url latest_mac['url']
+  sha256 latest_mac['sha256']
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@3.6.rb
+++ b/Formula/mongodb-community@3.6.rb
@@ -1,8 +1,25 @@
 class MongodbCommunityAT36 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
-  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.10.tgz"
-  sha256 "92dfc3b4571ad7c3855adff9fc878044296fcf69c2f8a1d5de554c0df588db88"
+
+  # frozen_string_literal: true
+
+  require 'net/http'
+  require 'json'
+  current = JSON.parse(Net::HTTP.get(URI('http://downloads.mongodb.org/current.json')))
+  latest = current['versions'].select { |r|
+    r['production_release'] == true \
+    && r['version'] =~ /^3\.6\.[0-9]+$/
+  }[0]
+  latest_mac = latest['downloads'].select { |m|
+    (m['target'] == 'osx-ssl' || m['target'] == 'macos') \
+    && m['edition'] == 'base'
+  } .map { |a|
+    a['archive']
+  }[0]
+
+  url latest_mac['url']
+  sha256 latest_mac['sha256']
 
   bottle :unneeded
 


### PR DESCRIPTION
Then when we do a major upgrade we can copy one of the existing ones and simply change the version regex.