### PR TITLE
Pin node version to 12

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -10,7 +10,7 @@ class Mongosh < Formula
   # curl -s https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.6.tgz | shasum -a 256
   sha256 "23bb944fc189778f72c7276806abe69a61e711b938d53645cfe8dd2668178313"
 
-  depends_on "node"
+  depends_on "node@12"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
With https://jira.mongodb.org/browse/MONGOSH-243 we exit with an error when the node version is not the one we expect (`^12.4.0` for `mongosh v0.0.6`). 

Because homebrew by default installs latest stable (14) when `node` is used as a dependency, mongosh installed with this formula refuses to start on systems where node isn't already installed and the homebrew one is used as the default.

With this PR we pin node to `v12`.