### PR TITLE
Always runs mongosh with node 12

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -13,8 +13,8 @@ class Mongosh < Formula
   depends_on "node@12"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    system "#{Formula["node@12"].bin}/npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"mongosh").write_env_script libexec/"bin/mongosh", :PATH => "#{Formula["node@12"].opt_bin}:$PATH"
   end
 
   test do


### PR DESCRIPTION
Fixed the install/link of the formula:
- Install uses node12's npm
- Install creates a wrapper script that puts Homebrew's node12 in PATH for mongosh to run.