### PR TITLE
Typo fix and update for Database Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,27 @@ $ brew install <formula>
 
 For example:
 
- * Install the latest available production release of MongoDB Community Server (including the [Database Tools](https://docs.mongodb.com/database-tools/)). This will currently install MongoDB 4.4.x:
+ * Install the latest available production release of MongoDB Community Server. This will currently install MongoDB 4.4.x:
    ```
    $ brew install mongodb-community
    ```
 
- * Install the latest 4.4.x production release of MongoDB Community Server and the Database Tools:
+ * Install the latest 4.4.x production release of MongoDB Community Server:
    ```
    $ brew install mongodb-community@4.4
    ```
 
-* Install the latest 4.2.x production release of MongoDB Community Server and the Database Tools:
+* Install the latest 4.2.x production release of MongoDB Community Server:
    ```
    $ brew install mongodb-community@4.2
    ```
 
- * Install the latest 4.0.x production release of MongoDB Community Server and the Database Tools:
+ * Install the latest 4.0.x production release of MongoDB Community Server:
    ```
    $ brew install mongodb-community@4.0
    ```
 
- * Install the latest 3.6.x production release of MongoDB Community Server and the Database Tools:
+ * Install the latest 3.6.x production release of MongoDB Community Server:
    ```
    $ brew install mongodb-community@3.6
    ```
@@ -52,7 +52,7 @@ For example:
    $ brew install mongodb-community-shell
    ```
 
- * Only install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/):
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/):
    ```
    $ brew install mongodb-database-tools
    ```

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ Once the tap has been added, use the instructions below to install the software 
 
 Use the commands in this section to install the latest version of the MongoDB Server, the shell, or the MongoDB Database Tools.
 
- * Install the latest available production release of [MongoDB Community Server](https://docs.mongodb.com/manual/). This includes the MongoDB Server processes `mongod` and `mongos`, the `mongo` shell, and `install_compass` to separately install [MongoDB Compass](https://docs.mongodb.com/compass/). Currently, this will install MongoDB Server 4.4.x:
+ * Install the latest available production release of [MongoDB Community Server](https://docs.mongodb.com/manual/). This includes the MongoDB Server processes `mongod` and `mongos`, the `mongo` shell, and `install_compass` to separately install [MongoDB Compass](https://docs.mongodb.com/compass/). Currently, this will install MongoDB Server 4.4.x.
  
    ```
    $ brew install mongodb-community
    ```
 
- * Install only the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances. If you installed the MongoDB Server in the step above, the shell was included in that installation. Use this command only if you need to install the `mongo` shell separately:
+ * Install only the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances. If you installed the MongoDB Server in the step above, the shell was included in that installation. Use this command only if you need to install the `mongo` shell separately.
 
    ```
    $ brew install mongodb-community-shell
    ```
 
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning. Use this command to install the MongoDB Database Tools:
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning.
 
    ```
    $ brew install mongodb-database-tools

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use the commands in this section to install the latest version of the MongoDB Se
    $ brew install mongodb-community-shell
    ```
 
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning.
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools released with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning.
 
    ```
    $ brew install mongodb-database-tools

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use the commands in this section to install the latest version of the MongoDB Se
    $ brew install mongodb-community-shell
    ```
 
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools released with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning.
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools released with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation and used matching versioning.
 
    ```
    $ brew install mongodb-database-tools

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use the commands in this section to install the latest version of the MongoDB Se
    $ brew install mongodb-community-shell
    ```
 
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning. Use this command to install the MongoDB Database Tools:
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning. Use this command to install the MongoDB Database Tools:
 
    ```
    $ brew install mongodb-database-tools

--- a/README.md
+++ b/README.md
@@ -22,27 +22,27 @@ $ brew install <formula>
 
 For example:
 
- * Install the latest available production release of MongoDB Community Server ([including all command line tools](https://docs.mongodb.com/manual/reference/program/)). This will currently install MongoDB 4.4.x:
+ * Install the latest available production release of MongoDB Community Server (including the [Database Tools](https://docs.mongodb.com/database-tools/)). This will currently install MongoDB 4.4.x:
    ```
    $ brew install mongodb-community
    ```
 
- * Install the latest 4.e.x production release of MongoDB Community Server and command line tools:
+ * Install the latest 4.4.x production release of MongoDB Community Server and the Database Tools:
    ```
    $ brew install mongodb-community@4.4
    ```
 
-* Install the latest 4.2.x production release of MongoDB Community Server and command line tools:
+* Install the latest 4.2.x production release of MongoDB Community Server and the Database Tools:
    ```
    $ brew install mongodb-community@4.2
    ```
 
- * Install the latest 4.0.x production release of MongoDB Community Server and command line tools:
+ * Install the latest 4.0.x production release of MongoDB Community Server and the Database Tools:
    ```
    $ brew install mongodb-community@4.0
    ```
 
- * Install the latest 3.6.x production release of MongoDB Community Server and command line tools:
+ * Install the latest 3.6.x production release of MongoDB Community Server and the Database Tools:
    ```
    $ brew install mongodb-community@3.6
    ```
@@ -50,6 +50,11 @@ For example:
  * Only install the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances:
    ```
    $ brew install mongodb-community-shell
+   ```
+
+ * Only install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/):
+   ```
+   $ brew install mongodb-database-tools
    ```
 
 ## Default Paths for the mongodb-community Formula

--- a/README.md
+++ b/README.md
@@ -14,18 +14,33 @@ $ brew tap mongodb/brew
 
 ## Installing Formulae
 
-Once the tap has been added locally, you can install individual software packages with:
+Once the tap has been added, use the instructions below to install the software packages you need. You can choose to install either the latest version of the MongoDB Server (recommended), or a specific version if desired.
 
-```
-$ brew install <formula>
-```
+### Installing the Latest MongoDB Server, Shell, or Database Tools
 
-For example:
+Use the commands in this section to install the latest version of the MongoDB Server, the shell, or the MongoDB Database Tools.
 
- * Install the latest available production release of MongoDB Community Server. This will currently install MongoDB 4.4.x:
+ * Install the latest available production release of [MongoDB Community Server](https://docs.mongodb.com/manual/). This includes the MongoDB Server processes `mongod` and `mongos`, the `mongo` shell, and `install_compass` to separately install [MongoDB Compass](https://docs.mongodb.com/compass/). Currently, this will install MongoDB Server 4.4.x:
+ 
    ```
    $ brew install mongodb-community
    ```
+
+ * Install only the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances. If you installed the MongoDB Server in the step above, the shell was included in that installation. Use this command only if you need to install the `mongo` shell separately:
+
+   ```
+   $ brew install mongodb-community-shell
+   ```
+
+ * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools release with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation nad used matching versioning. Use this command to install the MongoDB Database Tools:
+
+   ```
+   $ brew install mongodb-database-tools
+   ```
+
+### Installing a Specific Version of the MongoDB Server
+
+Alternatively, you can install a specific version of the MongoDB Server if desired.
 
  * Install the latest 4.4.x production release of MongoDB Community Server:
    ```
@@ -45,16 +60,6 @@ For example:
  * Install the latest 3.6.x production release of MongoDB Community Server:
    ```
    $ brew install mongodb-community@3.6
-   ```
-
- * Only install the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances:
-   ```
-   $ brew install mongodb-community-shell
-   ```
-
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/):
-   ```
-   $ brew install mongodb-database-tools
    ```
 
 ## Default Paths for the mongodb-community Formula
@@ -94,6 +99,14 @@ To shutdown `mongod` started manually, use the `admin` database and run `db.shut
 ```
 $ mongo admin --eval "db.shutdownServer()"
 ```
+
+## The Documentation
+
+For more information, please reference the following documentation:
+
+* [The MongoDB Server Manual](https://docs.mongodb.com/manual/)
+
+* [The MongoDB Database Tools Documentation](https://docs.mongodb.com/database-tools/)
 
 ## Additional Information and Problem Reporting
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ $ brew tap mongodb/brew
 
 Once the tap has been added, use the instructions below to install the software packages you need. You can choose to install either the latest version of the MongoDB Server (recommended), or a specific version if desired.
 
-### Installing the Latest MongoDB Server, Shell, or Database Tools
+### Installing the Latest mongodb-community Server, Shell, and the Database Tools Together
 
-Use the commands in this section to install the latest version of the MongoDB Server, the shell, or the MongoDB Database Tools.
-
- * Install the latest available production release of [MongoDB Community Server](https://docs.mongodb.com/manual/). This includes the MongoDB Server processes `mongod` and `mongos`, the `mongo` shell, and `install_compass` to separately install [MongoDB Compass](https://docs.mongodb.com/compass/). Currently, this will install MongoDB Server 4.4.x.
+ * Install the latest available production release of the [MongoDB Community Server](https://docs.mongodb.com/manual/). This includes the MongoDB Server processes `mongod` and `mongos`, the `mongo` shell, the [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), and the `install_compass` script to separately install [MongoDB Compass](https://docs.mongodb.com/compass/). Currently, this will install MongoDB Server 4.4.x.
  
    ```
    $ brew install mongodb-community
    ```
+
+### Installing only the Shell or the Database Tools
 
  * Install only the latest [`mongo` shell](https://docs.mongodb.com/manual/mongo/) for connecting to remote MongoDB instances. If you installed the MongoDB Server in the step above, the shell was included in that installation. Use this command only if you need to install the `mongo` shell separately.
 
@@ -32,13 +32,13 @@ Use the commands in this section to install the latest version of the MongoDB Se
    $ brew install mongodb-community-shell
    ```
 
- * Install the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. Starting with the MongoDB 4.4 Server release, the Database Tools are now [pacakged, versioned, and released independently](https://www.mongodb.com/blog/post/separating-database-tools-server) from the MongoDB Server package. The MongoDB Database Tools released with an initial version of `100.0.0`. Previously, the Database Tools were bundled with the MongoDB Server installation and used matching versioning.
+ * Install only the latest [MongoDB Database Tools](https://docs.mongodb.com/database-tools/), a suite of command-line tools (`mongoimport`, `mongoexport`, `mongodump`, etc) for working with a MongoDB Server instance. If you installed the MongoDB Server in the step above, the Database Tools were included in that installation. Use this command only if you need to install the Database Tools separately.
 
    ```
    $ brew install mongodb-database-tools
    ```
 
-### Installing a Specific Version of the MongoDB Server
+### Installing a Specific Version of the mongodb-community Server
 
 Alternatively, you can install a specific version of the MongoDB Server if desired.
 
@@ -98,6 +98,20 @@ To shutdown `mongod` started manually, use the `admin` database and run `db.shut
 
 ```
 $ mongo admin --eval "db.shutdownServer()"
+```
+
+## Uninstalling the mongodb-community Server
+
+If you need to uninstall the MongoDB Server, use:
+
+```
+$ brew uninstall mongodb-community
+```
+
+Note that this does not uninstall the bundled Database Tools. To uninstall the Database Tools, additionally run the folowing:
+
+```
+$ brew uninstall mongodb-database-tools
 ```
 
 ## The Documentation


### PR DESCRIPTION
• Small typo fix for 4.4 formula install step
• DB Tools links now link to DB Tools docs repo (not manual > reference > package contents)
• Updating name from 'command-line tools' to 'Database Tools' across the board.
• Added DB Tools-only install similar to shell-only install.

@rychipman for OKing DB Tools naming changes / link updates / install-only-DBTools step