### PR TITLE
SERVER-45930 Add new recommended dependency on mongodb-database-tools

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -9,6 +9,8 @@ class MongodbCommunity < Formula
 
   bottle :unneeded
 
+  depends_on "mongodb-database-tools" => :recommended
+
   def install
     prefix.install Dir["*"]
   end


### PR DESCRIPTION
The server tools are not distributed with MongoDB v4.4 and higher
anymore. From now on, there will be a recommended dependency on the
mongodb-database-tools package so that users who expected the tools to be
installed by default will get them, since that is the likely use case
for most users of this Homebrew tap. Users who do not want the tools
installed can now opt out of them.