### PR TITLE
SERVER-51790 add libmongocrypt formula

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,0 +1,33 @@
+class Libmongocrypt < Formula
+  desc "C library for Client Side Encryption"
+  homepage "https://github.com/mongodb/libmongocrypt"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.0.4.tar.gz"
+  sha256 "34244b473ceedd51f5885cd80ca3f818924fac4695b5cfcd5396092c726680d9"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "mongo-c-driver" => :build
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << if build.head?
+      "-DBUILD_VERSION=1.1.0-pre"
+    else
+      "-DBUILD_VERSION=1.0.4"
+    end
+    system "cmake", ".", *cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <mongocrypt/mongocrypt.h>
+      int main() {
+        const char* version = mongocrypt_version (0);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lmongocrypt", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This is the library used by drivers to support Client-Side Field Level Encryption.

The PR to merge in homebrew-core was closed (https://github.com/Homebrew/homebrew-core/pull/63229) since it is currently not notable enough (based on stars / watchers / and forks). The maintainers suggested hosting this on a tap.