### PR TITLE
Upgrade formula versions for mongodb-community

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -4,8 +4,8 @@ class MongodbCommunity < Formula
 
   # frozen_string_literal: true
 
-  url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.3.tgz"
-  sha256 "3d25c82e41b312b0d2b26199367e57b39fa9d8c2ee79ec0cba8d5960fbe41e29"
+  url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.4.tgz"
+  sha256 "8ae47e4f2ac2687fc0f64e8a299ec1797a10b94d131321ea17f9e0722e2e6463"
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@3.6.rb
+++ b/Formula/mongodb-community@3.6.rb
@@ -4,8 +4,8 @@ class MongodbCommunityAT36 < Formula
 
   # frozen_string_literal: true
 
-  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.20.tgz"
-  sha256 "1f288552e76519db335768437ef198f70473d40b887c748449f5e6f618bdfc15"
+  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.22.tgz"
+  sha256 "dcc51cf8ce248212456c9e014251e3c1d4f43c846477ebc50bbc31f73049d1bb"
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@4.0.rb
+++ b/Formula/mongodb-community@4.0.rb
@@ -4,8 +4,8 @@ class MongodbCommunityAT40 < Formula
 
   # frozen_string_literal: true
 
-  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.20.tgz"
-  sha256 "3446087766044c42150e22c564a5614ba8f661f17d671532896cb60a4172a01d"
+  url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.22.tgz"
+  sha256 "0113f595a0128245871fd54c2e534f93cc7d320792a3fd8cd287a4c4c9d0871d"
 
   bottle :unneeded
 

--- a/Formula/mongodb-community@4.2.rb
+++ b/Formula/mongodb-community@4.2.rb
@@ -4,8 +4,8 @@ class MongodbCommunityAT42 < Formula
 
   # frozen_string_literal: true
 
-  url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.9.tgz"
-  sha256 "57ce138e19a0aedfa1a5193b4ac6845436f49233e1b86eef4930fc50f3b5ed7e"
+  url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.12.tgz"
+  sha256 "06adf7b23ad3a3d97ae688d9001221c6cb263392ef74f3e265129b9b77b0a2e2"
 
   bottle :unneeded
 


### PR DESCRIPTION
Minor versions were outdated. Updated SHA256 hashes using this info: https://docs.mongodb.com/manual/tutorial/verify-mongodb-packages/#use-sha-256