### PR TITLE
chore: add new formula for mongocryptd MONGOSH-800

### DIFF
--- a/Aliases/mongodb-mongocryptd@4.4
+++ b/Aliases/mongodb-mongocryptd@4.4
@@ -1,0 +1,1 @@
+../Formula/mongodb-mongocryptd.rb

--- a/Formula/mongodb-mongocryptd.rb
+++ b/Formula/mongodb-mongocryptd.rb
@@ -1,0 +1,18 @@
+class MongodbMongocryptd < Formula
+  desc "mongocryptd service for Client Side Encryption"
+  homepage "https://www.mongodb.com/"
+
+  url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-4.4.6.tgz"
+  sha256 "bdf8aa2110b1f72c847b6b49f73fb855ae58549a2640ea69d7971740d7ff10db"
+  license "MongoDB Customer Agreement"
+
+  def caveats
+    <<~EOS
+      mongocryptd is licensed under the MongoDB Customer Agreement (https://www.mongodb.com/customer-agreement). Except for evaluation purposes, you may not use mongocryptd without a commercial license from MongoDB.
+    EOS
+  end
+
+  test do
+    system "#{bin}/mongocryptd", "--version"
+  end
+end

--- a/Formula/mongodb-mongocryptd.rb
+++ b/Formula/mongodb-mongocryptd.rb
@@ -12,6 +12,10 @@ class MongodbMongocryptd < Formula
     EOS
   end
 
+  def install
+    prefix.install Dir["*"]
+  end
+
   test do
     system "#{bin}/mongocryptd", "--version"
   end

--- a/Formula/mongodb-mongocryptd@4.2.rb
+++ b/Formula/mongodb-mongocryptd@4.2.rb
@@ -13,7 +13,7 @@ class MongodbMongocryptdAT42 < Formula
   end
 
   def install
-    bin.install "bin/mongocryptd"
+    prefix.install Dir["*"]
   end
 
   test do

--- a/Formula/mongodb-mongocryptd@4.2.rb
+++ b/Formula/mongodb-mongocryptd@4.2.rb
@@ -1,0 +1,22 @@
+class MongodbMongocryptdAT42 < Formula
+  desc "mongocryptd service for Client Side Encryption"
+  homepage "https://www.mongodb.com/"
+
+  url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-4.2.14.tgz"
+  sha256 "de76255ce9c6314df2dd002ec5a89511ff26835a21b67f391a00f6a2bc2bef3f"
+  license "MongoDB Customer Agreement"
+
+  def caveats
+    <<~EOS
+      mongocryptd is licensed under the MongoDB Customer Agreement (https://www.mongodb.com/customer-agreement). Except for evaluation purposes, you may not use mongocryptd without a commercial license from MongoDB.
+    EOS
+  end
+
+  def install
+    bin.install "bin/mongocryptd"
+  end
+
+  test do
+    system "#{bin}/mongocryptd", "--version"
+  end
+end


### PR DESCRIPTION
This PR adds 2 new formulas to allow easy installation of `mongocryptd` for users that require Client Side Field Level Encryption with `mongosh`.

The following formulas are added:
* `mongodb-mongocryptd`: which references the latest stable version `4.4.6`
* `mongodb-mongocryptd@4.2`: for server version `4.2.14`

The formula will show _caveats_ to point out the licensing:
![image](https://user-images.githubusercontent.com/4354632/120158687-b226cb80-c1f4-11eb-8432-26f0357ffde7.png)
