### PR TITLE
add mongosh as dependency to mongodb-community MONGOSH-128

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -10,6 +10,7 @@ class MongodbCommunity < Formula
   bottle :unneeded
 
   depends_on "mongodb-database-tools" => :recommended
+  depends_on "mongosh" => :recommended
 
   def install
     prefix.install Dir["*"]


### PR DESCRIPTION
This adds the `mongosh` formula as a `recommended` formula to the `mongodb-community` formula.

See https://jira.mongodb.org/browse/MONGOSH-128.