### PR TITLE
Error: Non-symlink alias when using brew tap mongodb/brew

### DIFF
--- a/Aliases/mongodb-community@4.4
+++ b/Aliases/mongodb-community@4.4
@@ -1,1 +1,1 @@
-../Formula/mongodb-community.rb
+../Formula/mongodb-community@4.2.rb

--- a/Aliases/mongodb-community@4.4
+++ b/Aliases/mongodb-community@4.4
@@ -1,1 +1,0 @@
-../Formula/mongodb-community@4.2.rb

--- a/Aliases/mongodb-mongocryptd@4.4
+++ b/Aliases/mongodb-mongocryptd@4.4
@@ -1,1 +1,0 @@
-../Formula/mongodb-mongocryptd@4.2.rb

--- a/Aliases/mongodb-mongocryptd@4.4
+++ b/Aliases/mongodb-mongocryptd@4.4
@@ -1,1 +1,1 @@
-../Formula/mongodb-mongocryptd.rb
+../Formula/mongodb-mongocryptd@4.2.rb


### PR DESCRIPTION
```
Cloning into '/usr/local/Homebrew/Library/Taps/mongodb/homebrew-brew'...
remote: Enumerating objects: 696, done.
remote: Counting objects: 100% (193/193), done.
remote: Compressing objects: 100% (173/173), done.
remote: Total 696 (delta 77), reused 44 (delta 17), pack-reused 503
Receiving objects: 100% (696/696), 153.34 KiB | 2.32 MiB/s, done.
Resolving deltas: 100% (315/315), done.
Error: Non-symlink alias: /usr/local/Homebrew/Library/Taps/mongodb/homebrew-brew/Aliases/mongodb-community@4.4
Error: Non-symlink alias: /usr/local/Homebrew/Library/Taps/mongodb/homebrew-brew/Aliases/mongodb-mongocryptd@4.4
Error: Cannot tap mongodb/brew: invalid syntax in tap!
```
We can fix it by removing files in Aliases folder. I am not sure if this is the right thing to do.
However, after deleting the files, ```brew tap mongodb/brew``` succeeded.