### PR TITLE
Remove deprecated 'bottle :unneeded' to avoid warnings

### DIFF
--- a/Formula/mongocli.rb
+++ b/Formula/mongocli.rb
@@ -7,7 +7,6 @@ class Mongocli < Formula
   homepage "https://github.com/mongodb/mongocli"
   version "1.16.0"
   license "Apache-2.0"
-  bottle :unneeded
   deprecate! date: "2021-06-08", because: "moved to hombrew-core"
 
   if OS.mac? && Hardware::CPU.intel?

--- a/Formula/mongodb-community-shell.rb
+++ b/Formula/mongodb-community-shell.rb
@@ -7,8 +7,6 @@ class MongodbCommunityShell < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-shell-macos-x86_64-5.0.0.tgz"
   sha256 "4848d8fa25f3dd82f4af55ca0ad07c22a3491e47903c942427e1395a59077b9b"
 
-  bottle :unneeded
-
   def install
     prefix.install Dir["*"]
   end

--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -7,8 +7,6 @@ class MongodbCommunity < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-5.0.3.tgz"
   sha256 "fad04d5b2bc184d0ab0487889298d70ac1f6368043196b73d212a509848e2515"
 
-  bottle :unneeded
-
   depends_on "mongodb-database-tools" => :recommended
   depends_on "mongosh" => :recommended
 

--- a/Formula/mongodb-community@3.2.rb
+++ b/Formula/mongodb-community@3.2.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT32 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.2.22.tgz"
   sha256 "0f85d6e1810993cf3c02216a8b8abe20c0cde3d1fb6a9ac445ca26819f3cc2c9"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   def install

--- a/Formula/mongodb-community@3.4.rb
+++ b/Formula/mongodb-community@3.4.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT34 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.4.24.tgz"
   sha256 "ee0591f1c2d4607a5ab714b6f634212575244af2346d41a2fe8ab28d6abb6f36"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   def install

--- a/Formula/mongodb-community@3.6.rb
+++ b/Formula/mongodb-community@3.6.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT36 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.23.tgz"
   sha256 "f75883dae932590201b8e36b2591da4f267cf56cbc57755b389b76c1fe3d5b31"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   def install

--- a/Formula/mongodb-community@4.0.rb
+++ b/Formula/mongodb-community@4.0.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT40 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.27.tgz"
   sha256 "9424886b0f04a33eb2bf792bea602243adc7e880ee0552e356df5affe0385099"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   def install

--- a/Formula/mongodb-community@4.2.rb
+++ b/Formula/mongodb-community@4.2.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT42 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.17.tgz"
   sha256 "a13af71ab422b2776f9f5d9028c53f8e2322ec6d37f57ad4d36d711070193d00"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   def install

--- a/Formula/mongodb-community@4.4.rb
+++ b/Formula/mongodb-community@4.4.rb
@@ -7,8 +7,6 @@ class MongodbCommunityAT44 < Formula
   url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.9.tgz"
   sha256 "b094a5d4eee07d5eb4e308909b2a1eb589fe7b653d8322f9fc9e06d4d682980c"
 
-  bottle :unneeded
-
   depends_on "mongodb-database-tools" => :recommended
 
   keg_only :versioned_formula

--- a/Formula/mongodb-database-tools.rb
+++ b/Formula/mongodb-database-tools.rb
@@ -7,8 +7,6 @@ class MongodbDatabaseTools < Formula
   url "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-macos-x86_64-100.5.0.zip"
   sha256 "3bd4b4c570def5054d0046a90e25c6540b592ac6492efa07e1d429854f9f50b3"
 
-  bottle :unneeded
-
   def install
     prefix.install Dir["*"]
   end


### PR DESCRIPTION
Remove the deprecated `bottle :unneeded` to avoid generating 'Warning's during `brew update`.