### PR TITLE
Add ipv6: true to the default configuration file

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -31,6 +31,7 @@ class MongodbCommunity < Formula
       dbPath: #{var}/mongodb
     net:
       bindIp: 127.0.0.1
+      ipv6: true
   EOS
   end
 

--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -30,7 +30,7 @@ class MongodbCommunity < Formula
     storage:
       dbPath: #{var}/mongodb
     net:
-      bindIp: 127.0.0.1
+      bindIp: 127.0.0.1, ::1
       ipv6: true
   EOS
   end


### PR DESCRIPTION
## Motivation
The [default mac hosts file](https://gist.github.com/andretw/e3946bd9c9b4571702e5) includes an IPv6 alias for localhost. The default behavior of the [nodejs mongodb client](https://docs.mongodb.com/drivers/node/current/fundamentals/connection/#connection-options) is to attempt a connection with IPv6 before falling back to IPv4. I was getting connection errors until I went and added `ipv6: true` to the mongod configuration file and then it connected just fine.

My impression is that given the default in the hostfile, it would be better for the homebrew installation to assume IPv6 by default.

## Changes
* Add `ipv6: true` to the default configuration file for installation