### PR TITLE
update libmongocrypt to 1.5.0

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,10 +1,10 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.4.1.tar.gz"
-  sha256 "15f118ac42a9df9dd86af2d93bd763bbc128977b73cfd430cb1d6270350e344e"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.5.0.tar.gz"
+  sha256 "d96f0fae590e69ed37979aad27db191a9b804d4e16ea74d5ce1a16520fd1c053"
   license "Apache-2.0"
-  head "https://github.com/mongodb/libmongocrypt.git", tag: "1.5.0-rc2"
+  head "https://github.com/mongodb/libmongocrypt.git"
 
   depends_on "cmake" => :build
   depends_on "mongo-c-driver" => :build
@@ -12,9 +12,9 @@ class Libmongocrypt < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << if build.head?
-      "-DBUILD_VERSION=1.5.0-rc2"
+      "-DBUILD_VERSION=1.6.0-pre"
     else
-      "-DBUILD_VERSION=1.4.1"
+      "-DBUILD_VERSION=1.5.0"
     end
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -4,7 +4,7 @@ class Libmongocrypt < Formula
   url "https://github.com/mongodb/libmongocrypt/archive/1.4.1.tar.gz"
   sha256 "15f118ac42a9df9dd86af2d93bd763bbc128977b73cfd430cb1d6270350e344e"
   license "Apache-2.0"
-  head "https://github.com/mongodb/libmongocrypt.git", tag: "1.5.0-rc1"
+  head "https://github.com/mongodb/libmongocrypt.git", tag: "1.5.0-rc2"
 
   depends_on "cmake" => :build
   depends_on "mongo-c-driver" => :build
@@ -12,7 +12,7 @@ class Libmongocrypt < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << if build.head?
-      "-DBUILD_VERSION=1.5.0-rc1"
+      "-DBUILD_VERSION=1.5.0-rc2"
     else
       "-DBUILD_VERSION=1.4.1"
     end

--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.4.0.tar.gz"
-  sha256 "4185a5a0cf4aee1f211dfd3dc28310234fa278d1e696ee15beb0dccbf102388f"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.4.1.tar.gz"
+  sha256 "15f118ac42a9df9dd86af2d93bd763bbc128977b73cfd430cb1d6270350e344e"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git", tag: "1.5.0-rc1"
 
@@ -14,7 +14,7 @@ class Libmongocrypt < Formula
     cmake_args << if build.head?
       "-DBUILD_VERSION=1.5.0-rc1"
     else
-      "-DBUILD_VERSION=1.4.0"
+      "-DBUILD_VERSION=1.4.1"
     end
     system "cmake", ".", *cmake_args
     system "make", "install"


### PR DESCRIPTION
Tested from a fork with the following:
```
$ brew install kevinAlbs/brew/libmongocrypt
...
$ pkg-config --modversion libmongocrypt
1.5.0
```

```
$ brew install kevinAlbs/brew/libmongocrypt --HEAD
...
$ pkg-config --modversion libmongocrypt
1.6.0-pre
```