### PR TITLE
bump libmongocrypt to 1.5.2

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.5.0.tar.gz"
-  sha256 "d96f0fae590e69ed37979aad27db191a9b804d4e16ea74d5ce1a16520fd1c053"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.5.2.tar.gz"
+  sha256 "8d5a456c863194f4f844e6afdb01a29fd4bc14755af5359e378e972e2d4a8b06"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -14,7 +14,7 @@ class Libmongocrypt < Formula
     cmake_args << if build.head?
       "-DBUILD_VERSION=1.6.0-pre"
     else
-      "-DBUILD_VERSION=1.5.0"
+      "-DBUILD_VERSION=1.5.2"
     end
     system "cmake", ".", *cmake_args
     system "make", "install"


### PR DESCRIPTION
This release addresses a severe and urgent bug fix: MONGOCRYPT-464.

Tested from a fork with the following:

```
$ brew install kevinAlbs/brew/libmongocrypt
...
$ pkg-config --modversion libmongocrypt
1.5.2
```