### PR TITLE
Switch to modern service definition

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -51,45 +51,12 @@ class MongodbCommunity < Formula
     end
     cfg
   end
-
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+ 
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-community@4.2.rb
+++ b/Formula/mongodb-community@4.2.rb
@@ -44,44 +44,11 @@ class MongodbCommunityAT42 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-community@4.4.rb
+++ b/Formula/mongodb-community@4.4.rb
@@ -46,44 +46,11 @@ class MongodbCommunityAT44 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-community@5.0.rb
+++ b/Formula/mongodb-community@5.0.rb
@@ -47,44 +47,11 @@ class MongodbCommunityAT50 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-enterprise.rb
+++ b/Formula/mongodb-enterprise.rb
@@ -60,44 +60,11 @@ class MongodbEnterprise < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-enterprise@4.2.rb
+++ b/Formula/mongodb-enterprise@4.2.rb
@@ -51,44 +51,11 @@ class MongodbEnterpriseAT42 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-enterprise@4.4.rb
+++ b/Formula/mongodb-enterprise@4.4.rb
@@ -53,44 +53,11 @@ class MongodbEnterpriseAT44 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do

--- a/Formula/mongodb-enterprise@5.0.rb
+++ b/Formula/mongodb-enterprise@5.0.rb
@@ -54,44 +54,11 @@ class MongodbEnterpriseAT50 < Formula
     cfg
   end
 
-  plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/mongod</string>
-        <string>--config</string>
-        <string>#{etc}/mongod.conf</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/mongodb/output.log</string>
-      <key>HardResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-      <key>SoftResourceLimits</key>
-      <dict>
-        <key>NumberOfFiles</key>
-        <integer>64000</integer>
-      </dict>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"mongod", "--config", etc/"mongod.conf"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/mongodb/output.log"
+    error_log_path var/"log/mongodb/output.log"
   end
 
   test do


### PR DESCRIPTION
Homebrew has officially deprecated the `plist_options` command, causing various invocations of `brew` (including many that don't reference MongoDB at all) to issue noisy warnings for each mongodb formula, e.g.:

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the mongodb/brew tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/mongodb/homebrew-brew/Formula/mongodb-community.rb:55
```

The deprecation message refers to the `service.require_root` option, but that suggestion applies to the use of `plist_options :startup`. For `plist_options :manual` as used by the MongoDB formulae, the expected course of action is to remove the manually specified plist entirely and specify an equivalent `service` block. At this time, there is no way to specify the `Hard/SoftResourceLimits` options in a `service` block, but the default limits for a properly configured service on macOS Monterey and Ventura appear to already be adequate (per the output of `sysctl kern.maxfiles{,perproc}`), so I haven't made any effort to address it for now.

The `service` block generates a correctly configured plist on macOS; it should also generate a working service file on Linux (although I did not test that).

(Note: The explicit deprecation message only appears for those running Homebrew at HEAD, and has been temporarily reverted due to unrelated problems caused by other changes made in the same commit, but is scheduled to be re-enabled in the upcoming 3.7.0 release. It's my understanding that switching to `service` blocks has been the recommendation for quite a while now, and if there _is_ an issue due to the resource limits concern, tackling this now improves the chances that Homebrew can add additional support upstream before the deprecation warnings start showing up for all users.)

References:
https://github.com/Homebrew/homebrew-core/pull/121456
https://docs.brew.sh/Formula-Cookbook#service-files
https://github.com/Homebrew/brew/pull/14382
https://github.com/Homebrew/brew/pull/14548
https://github.com/Homebrew/brew/issues/14542