### PR TITLE
Update service startup to work with homebrew 4.2

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -40,6 +40,10 @@ class MongodbCommunity < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-community@4.4.rb
+++ b/Formula/mongodb-community@4.4.rb
@@ -35,6 +35,10 @@ class MongodbCommunityAT44 < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-community@5.0.rb
+++ b/Formula/mongodb-community@5.0.rb
@@ -36,6 +36,10 @@ class MongodbCommunityAT50 < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-community@6.0.rb
+++ b/Formula/mongodb-community@6.0.rb
@@ -40,6 +40,10 @@ class MongodbCommunityAT60 < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-enterprise.rb
+++ b/Formula/mongodb-enterprise.rb
@@ -49,6 +49,10 @@ class MongodbEnterprise < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-enterprise@4.4.rb
+++ b/Formula/mongodb-enterprise@4.4.rb
@@ -42,6 +42,10 @@ class MongodbEnterpriseAT44 < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-enterprise@5.0.rb
+++ b/Formula/mongodb-enterprise@5.0.rb
@@ -43,6 +43,10 @@ class MongodbEnterpriseAT50 < Formula
     end
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def mongodb_conf
     cfg = <<~EOS
     systemLog:

--- a/Formula/mongodb-enterprise@6.0.rb
+++ b/Formula/mongodb-enterprise@6.0.rb
@@ -41,6 +41,10 @@ class MongodbEnterpriseAT60 < Formula
     prefix.install Dir["*"]
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   def post_install
     (var/"mongodb").mkpath
     (var/"log/mongodb").mkpath


### PR DESCRIPTION
Homebrew seems to have changed the way it starts up services, now we need to use the service stanza: https://docs.brew.sh/Formula-Cookbook#service-files

This was reported in homebrew as well:
https://github.com/Homebrew/homebrew-services/issues/607

Tested with these commands:
```
brew untap mongodb/homebrew-brew
brew tap dmoody256/homebrew-brew
brew install mongodb-community
brew services restart mongodb/brew/mongodb-community
ps aux | grep mongod
```