### PR TITLE
feat MongoDB Enterprise 8.0 formula for Homebrew

### DIFF
--- a/Formula/mongodb-enterprise@8.0.rb
+++ b/Formula/mongodb-enterprise@8.0.rb
@@ -1,0 +1,80 @@
+class MongodbEnterpriseAT60 < Formula
+  desc "High-performance, schema-free, document-oriented database (Enterprise)"
+  homepage "https://www.mongodb.com/"
+
+  # frozen_string_literal: true
+  #
+  if Hardware::CPU.intel?
+    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-8.0.0-rc4.tgz"
+    sha256 "2567d428183095d2903a59ff50bcfb37dea1bff041d61102da29963ce62b6862"
+  else
+    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-8.0.0-rc4.tgz"
+    sha256 "7b5b0bde7574b0e2e19d2c56049761fc31f953653ac78ebbccd30437872e3f7a"
+  end
+
+  license "MongoDB Customer Agreement"
+
+  def caveats
+    <<~EOS
+      MongoDB Enterprise is licensed under the MongoDB Customer Agreement (https://www.mongodb.com/customer-agreement). Except for evaluation purposes, you may not use MongoDB Enterprise without a commercial license from MongoDB.
+    EOS
+  end
+
+  option "with-enable-test-commands", "Configures MongoDB to allow test commands such as failpoints"
+
+  depends_on "mongodb-database-tools" => :recommended
+  depends_on "mongosh" => :recommended
+
+  conflicts_with "mongodb-community"
+
+  def install
+    
+    inreplace "macos_mongodb.plist" do |s|
+      s.gsub!("\#{plist_name}", "#{plist_name}")
+      s.gsub!("\#{opt_bin}", "#{opt_bin}")
+      s.gsub!("\#{etc}", "#{etc}")
+      s.gsub!("\#{HOMEBREW_PREFIX}", "#{HOMEBREW_PREFIX}")
+      s.gsub!("\#{var}", "#{var}")
+    end
+
+    prefix.install_symlink "macos_mongodb.plist" => "#{plist_name}.plist"
+    prefix.install Dir["*"]
+  end
+
+  service do
+    name macos: "#{plist_name}"
+  end
+
+  def post_install
+    (var/"mongodb").mkpath
+    (var/"log/mongodb").mkpath
+    if !(File.exist?((etc/"mongod.conf"))) then
+      (etc/"mongod.conf").write mongodb_conf
+    end
+  end
+
+  def mongodb_conf
+    cfg = <<~EOS
+    systemLog:
+      destination: file
+      path: #{var}/log/mongodb/mongo.log
+      logAppend: true
+    storage:
+      dbPath: #{var}/mongodb
+    net:
+      bindIp: 127.0.0.1, ::1
+      ipv6: true
+    EOS
+    if build.with? "enable-test-commands"
+      cfg += <<~EOS
+      setParameter:
+        enableTestCommands: 1
+      EOS
+    end
+    cfg
+  end
+
+  test do
+    system "#{bin}/mongod", "--sysinfo"
+  end
+end


### PR DESCRIPTION
This commit introduces the Homebrew formula for MongoDB Enterprise 8.0. It includes support for both Intel and ARM architectures, with the necessary URLs and SHA256 checksums for each. The formula also handles conflicts with the mongodb-community package and includes caveats regarding the MongoDB Customer Agreement. Additionally, it sets up the plist for the macOS service and provides a default mongod.conf configuration file. An option to enable test commands is available for users who need it. The post_install step ensures the creation of necessary directories for MongoDB operation.