### PR TITLE
Fix SHA256 for mongodb-community arm

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -9,7 +9,7 @@ class MongodbCommunity < Formula
     sha256 "9b0f70feacf7c41542ee7d0905e2f8090b09d5b8413f0c9079406c09afd7a2c0"
   else
     url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.14.tgz"
-    sha256 "8805f8b33801cd07b90118c25e507b0de21c6ad426b375fbe49e896ffc575d0e"
+    sha256 "bf0e5deab684278a2014af55e38abad8a119ea1ef45d79d762e0c1795efe53b7"
   end
 
   option "with-enable-test-commands", "Configures MongoDB to allow test commands such as failpoints"


### PR DESCRIPTION
I'm opening this PR because I'm getting an error while trying to install mongodb-community using brew.

I don't have the knowledge/access to do a security check on the file being downloaded to see if is compromised or not, so please let me know if it is safe to update the hash. I just downloaded the file, generated the hash and updated it here.

It looks like the Intel SHA should also be updated but I didn't do that because I don't have an Intel Mac to test, but let me know if I should update it too.