### PR TITLE
Fix incorrect class name which is not allowing installation of mongodb 7.0

### DIFF
--- a/Formula/mongodb-community@7.0.rb
+++ b/Formula/mongodb-community@7.0.rb
@@ -1,4 +1,4 @@
-class MongodbCommunity < Formula
+class MongodbCommunityAT70 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
 


### PR DESCRIPTION
Trying to install MongoDB 7.0, following the mongodb docs:

```
 brew install mongodb-community@7.0
```

gives the error:

```
Error: No available formula with the name "mongodb/brew/mongodb-community@7.0". Did you mean mongodb/brew/mongodb-community@5.0, mongodb/brew/mongodb-community@6.0, mongodb/brew/mongodb-community, mongodb/brew/mongodb-community@4.4, mongodb/brew/mongodb-community-shell, mongodb/brew/mongodb-community-shell@4.4, mongodb/brew/mongodb-mongocryptd@7.0 or mongodb/brew/mongodb-enterprise@7.0?
In formula file: /usr/local/Homebrew/Library/Taps/mongodb/homebrew-brew/Formula/mongodb-community@7.0.rb
Expected to find class MongodbCommunityAT70, but only found: MongodbCommunity.
```

It looks like you upgraded the default to 8.0 recently, and moved 7.0 to a formula, which the class should be named `MongodbCommunityAT70` 

Please merge this as I cannot install 7.0 right now