### PR TITLE
fix: class name for `mongodb-community@7.0.rb`

### DIFF
--- a/Formula/mongodb-community@7.0.rb
+++ b/Formula/mongodb-community@7.0.rb
@@ -1,4 +1,4 @@
-class MongodbCommunity < Formula
+class MongodbCommunityAT70 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
 


### PR DESCRIPTION
Fix an issue with the MongoDB Community Edition 7.0 formula where the class name was incorrect, resulting in installation failure via Homebrew. The error message specifically expected a class named `MongodbCommunityAT70` but found `MongodbCommunity` instead.

## Changes

Updated the class name in `mongodb-community@7.0.rb` from `MongodbCommunity` to `MongodbCommunityAT70` to align with the versioned formula naming convention.

## Error Message

The original error was:

```
$ brew install mongodb-community@7.0
...
Error: No available formula with the name "mongodb/brew/mongodb-community@7.0". Did you mean mongodb/brew/mongodb-community@5.0, mongodb/brew/mongodb-community@6.0, mongodb/brew/mongodb-community, mongodb/brew/mongodb-community@4.4, mongodb/brew/mongodb-community-shell, mongodb/brew/mongodb-community-shell@4.4, mongodb/brew/mongodb-mongocryptd@7.0 or mongodb/brew/mongodb-enterprise@7.0?
In formula file: /opt/homebrew/Library/Taps/mongodb/homebrew-brew/Formula/mongodb-community@7.0.rb
Expected to find class MongodbCommunityAT70, but only found: MongodbCommunity.
```
