### PR TITLE
DEVPROD-11495 Add AT70 suffix to 7.0 Homebrew formulae

### DIFF
--- a/Formula/mongodb-community@7.0.rb
+++ b/Formula/mongodb-community@7.0.rb
@@ -1,4 +1,4 @@
-class MongodbCommunity < Formula
+class MongodbCommunityAT70 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
 

--- a/Formula/mongodb-enterprise@7.0.rb
+++ b/Formula/mongodb-enterprise@7.0.rb
@@ -1,4 +1,4 @@
-class MongodbEnterprise < Formula
+class MongodbEnterpriseAT70 < Formula
   desc "High-performance, schema-free, document-oriented database (Enterprise)"
   homepage "https://www.mongodb.com/"
 

--- a/Formula/mongodb-mongocryptd@7.0.rb
+++ b/Formula/mongodb-mongocryptd@7.0.rb
@@ -1,4 +1,4 @@
-class MongodbMongocryptd < Formula
+class MongodbMongocryptdAT70 < Formula
   desc "mongocryptd service for Client Side Encryption"
   homepage "https://www.mongodb.com/"
 


### PR DESCRIPTION
The homebrew formulae for the 7.0 packages is incorrect - the file was renamed during the 8.0 release but the class also needs to be renamed to add an AT70 suffix

