### PR TITLE
MONGOCRYPT-732 update to libmongocrypt 1.12.0

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.11.0.tar.gz"
-  sha256 "9891ec8d1015ed3711e4d7d515a74eb4143a0ff1ce8ff8795de63cb921fee2d6"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.12.0.tar.gz"
+  sha256 "6f4d5eca873e36492e4150cce23f84311fc0fcbfeffaad64971d2b2f34996d3c"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -12,9 +12,9 @@ class Libmongocrypt < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << if build.head?
-      "-DBUILD_VERSION=1.12.0-pre"
+      "-DBUILD_VERSION=1.13.0-pre"
     else
-      "-DBUILD_VERSION=1.11.0"
+      "-DBUILD_VERSION=1.12.0"
     end
     # Homebrew includes FETCHCONTENT_FULLY_DISCONNECTED=ON as part of https://github.com/Homebrew/brew/pull/17075
     # Set back the previous default to prevent build failure.


### PR DESCRIPTION
# Summary

Update libmongocrypt formula to 1.12.0

# Background & Motivation

Tested from a fork with the following:
```
% brew install kevinAlbs/brew/libmongocrypt
[...]
% pkg-config --modversion libmongocrypt
1.12.0
```