### PR TITLE
update libmongocrypt to 1.13.1

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.12.0.tar.gz"
-  sha256 "6f4d5eca873e36492e4150cce23f84311fc0fcbfeffaad64971d2b2f34996d3c"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.13.0.tar.gz"
+  sha256 "56504839ae699da8311e5d24887952376564d103b1974915db9e226047e72cdc"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -12,9 +12,9 @@ class Libmongocrypt < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << if build.head?
-      "-DBUILD_VERSION=1.13.0-pre"
+      "-DBUILD_VERSION=1.14.0-pre"
     else
-      "-DBUILD_VERSION=1.12.0"
+      "-DBUILD_VERSION=1.13.0"
     end
     # Homebrew includes FETCHCONTENT_FULLY_DISCONNECTED=ON as part of https://github.com/Homebrew/brew/pull/17075
     # Set back the previous default to prevent build failure.

--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.13.0.tar.gz"
-  sha256 "56504839ae699da8311e5d24887952376564d103b1974915db9e226047e72cdc"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.13.1.tar.gz"
+  sha256 "7d7cbac0faa29dce2da9c1da10015a38324021b59d46a9815f08211941ed36c4"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -14,7 +14,7 @@ class Libmongocrypt < Formula
     cmake_args << if build.head?
       "-DBUILD_VERSION=1.14.0-pre"
     else
-      "-DBUILD_VERSION=1.13.0"
+      "-DBUILD_VERSION=1.13.1"
     end
     # Homebrew includes FETCHCONTENT_FULLY_DISCONNECTED=ON as part of https://github.com/Homebrew/brew/pull/17075
     # Set back the previous default to prevent build failure.


### PR DESCRIPTION
# Summary

Update libmongocrypt formula to 1.13.1

# Background & Motivation

Tested from a fork with the following:
```
% brew install kevinAlbs/brew/libmongocrypt
[...]
% pkg-config --modversion libmongocrypt
1.13.1
```
