### PR TITLE
update libmongocrypt for 1.15.0

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.14.1.tar.gz"
-  sha256 "6b7e7cbf97d18314c9d75a88d7ed2eb7efb59f7ab695e91c10589cccc64278f9"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.15.0.tar.gz"
+  sha256 "ed25d5fdbfb6a632885db82b5ca36697f7e6222bfb93eb96be62e886786986e1"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -12,9 +12,9 @@ class Libmongocrypt < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << if build.head?
-      "-DBUILD_VERSION=1.15.0-pre"
+      "-DBUILD_VERSION=1.16.0-pre"
     else
-      "-DBUILD_VERSION=1.14.1"
+      "-DBUILD_VERSION=1.15.0"
     end
     # Homebrew includes FETCHCONTENT_FULLY_DISCONNECTED=ON as part of https://github.com/Homebrew/brew/pull/17075
     # Set back the previous default to prevent build failure.


### PR DESCRIPTION
# Summary

Update libmongocrypt formula to 1.15.0

# Background & Motivation

Tested from a fork with the following:
```
% brew install kevinAlbs/brew/libmongocrypt
[...]
% pkg-config --modversion libmongocrypt
1.15.0
```
