### PR TITLE
update for 1.16.0

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -21,6 +21,10 @@ class Libmongocrypt < Formula
     cmake_args << "-DMONGOCRYPT_MONGOC_DIR=USE-SYSTEM"
     cmake_args << "-DUSE_SHARED_LIBBSON=ON"
     cmake_args << "-DENABLE_ONLINE_TESTS=OFF"
+
+    # Allow FetchContent to build the bundled IntelDFP tarball.
+    cmake_args << "-DHOMEBREW_ALLOW_FETCHCONTENT=ON"
+
     system "cmake", ".", *cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
# Summary

Update libmongocrypt formula to 1.16.0.

## Details

This includes changes to fix an observed build error when upgrading from 1.15.1 to 1.16.0:
```
-- Downloading mongo-c-driver 2.1.0 for libbson
CMake Error at /opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake:12 (message):
  Refusing to populate dependency 'embedded_mcd' with FetchContent while
  building in Homebrew, please use a formula dependency or add a resource to
  the formula.
```

I expect this restriction is to avoid remote requests. This appears triggered by https://github.com/mongodb/libmongocrypt/commit/6d8de05f111b565bb38abf7ba445a6bb1afa00d3 made in [MONGOCRYPT-839](https://jira.mongodb.org/browse/MONGOCRYPT-839):

> `FetchContent_MakeAvailable()` is used to populate dependencies instead of `FetchContent_Populate()`.

libmongocrypt uses `FetchContent` to get two dependencies if needed: libbson and IntelDFP. The homebrew package already had an (unused) package dependency on `mongo-c-driver`. This PR now uses the libbson from the package dependency, rather than fetching remotely.

`-DHOMEBREW_ALLOW_FETCHCONTENT=ON` is added to support the IntelDFP dependency. The call to `FetchContent` uses the [bundled tarball](https://github.com/mongodb/libmongocrypt/tree/9c8522fc2a527606dd078592a1f14a800b2abb96/third-party) rather than making a remote request.
# Background & Motivation

Tested from a fork with the following:
```
% brew install kevinAlbs/brew/libmongocrypt
[...]
% pkg-config --modversion libmongocrypt
1.16.0
```
