### PR TITLE
Fix MongoDB 8.2 formula class names

### DIFF
--- a/Formula/mongodb-community@8.2.rb
+++ b/Formula/mongodb-community@8.2.rb
@@ -1,4 +1,4 @@
-class MongodbCommunity < Formula
+class MongodbCommunityAT82 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
 

--- a/Formula/mongodb-enterprise@8.2.rb
+++ b/Formula/mongodb-enterprise@8.2.rb
@@ -1,4 +1,4 @@
-class MongodbEnterprise < Formula
+class MongodbEnterpriseAT82 < Formula
   desc "High-performance, schema-free, document-oriented database (Enterprise)"
   homepage "https://www.mongodb.com/"
 

--- a/Formula/mongodb-mongocryptd@8.2.rb
+++ b/Formula/mongodb-mongocryptd@8.2.rb
@@ -1,4 +1,4 @@
-class MongodbMongocryptd < Formula
+class MongodbMongocryptdAT82 < Formula
   desc "mongocryptd service for Client Side Encryption"
   homepage "https://www.mongodb.com/"
 


### PR DESCRIPTION
## Summary
Fixes the class names for the MongoDB 8.2 versioned formulae so Homebrew can import them correctly.

## Details
Homebrew expects versioned formula files named `*@8.2.rb` to define `...AT82` classes. The current files define the unversioned class names instead, which causes import failures such as:

`Expected to find class MongodbCommunityAT82, but only found: MongodbCommunity.`

Updated:
- `mongodb-community@8.2.rb`: `MongodbCommunityAT82`
- `mongodb-enterprise@8.2.rb`: `MongodbEnterpriseAT82`
- `mongodb-mongocryptd@8.2.rb`: `MongodbMongocryptdAT82`

## Verification
- `git diff --check`
- `ruby -c Formula/mongodb-community@8.2.rb`
- `ruby -c Formula/mongodb-enterprise@8.2.rb`
- `ruby -c Formula/mongodb-mongocryptd@8.2.rb`
- `rg -n '^class Mongodb(CommunityAT82|EnterpriseAT82|MongocryptdAT82) < Formula$' Formula/mongodb-community@8.2.rb Formula/mongodb-enterprise@8.2.rb Formula/mongodb-mongocryptd@8.2.rb`
- `brew test-bot --only-tap-syntax --dry-run`

Note: `brew info --formula ./Formula/...` is rejected by Homebrew 6 outside an installed tap path, so I used the tap syntax dry run plus syntax/class-name checks from this separate clone.