### PR TITLE
update libmongocrypt to 1.20.1

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,8 +1,8 @@
 class Libmongocrypt < Formula
   desc "C library for Client Side Encryption"
   homepage "https://github.com/mongodb/libmongocrypt"
-  url "https://github.com/mongodb/libmongocrypt/archive/1.20.0.tar.gz"
-  sha256 "e8693ad6288aad53a487bcd437a3abefa0d386742bc75e24ad9530a2ef293493"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.20.1.tar.gz"
+  sha256 "ebbbac83988d1831c9ebb7e7fc87a26abf236ac2eaa6eb451ec888a44dc12829"
   license "Apache-2.0"
   head "https://github.com/mongodb/libmongocrypt.git"
 
@@ -13,7 +13,7 @@ class Libmongocrypt < Formula
     cmake_args << if build.head?
       "-DBUILD_VERSION=1.21.0-pre"
     else
-      "-DBUILD_VERSION=1.20.0"
+      "-DBUILD_VERSION=1.20.1"
     end
 
     cmake_args << "-DENABLE_ONLINE_TESTS=OFF"


### PR DESCRIPTION
# Summary

Update libmongocrypt formula from 1.20.0 to 1.20.1.

libmongocrypt 1.20.1 includes a fix for CMake 4.4.0: [MONGOCRYPT-952](https://jira.mongodb.org/browse/MONGOCRYPT-952). This is [impacting users](https://mongodb.slack.com/archives/CDM9QEGUT/p1784313077633159) installing on Homebrew since Homebrew now includes CMake 4.4.0.

## Details

Tested from a fork with the following:
```
% cmake --version | HEAD -1
cmake version 4.4.0
% brew install kevinAlbs/brew/libmongocrypt
[...]
% pkg-config --modversion libmongocrypt
1.20.0
```