### PR TITLE
Update Homebrew formulae for MongoDB 7.0.39

### DIFF
--- a/Formula/mongodb-community@7.0.rb
+++ b/Formula/mongodb-community@7.0.rb
@@ -5,11 +5,11 @@ class MongodbCommunityAT70 < Formula
   # frozen_string_literal: true
 
   if Hardware::CPU.intel?
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.37.tgz"
-    sha256 "661200efa742cb67f82a61d857b57e7321959c1ac2a4e53dc0aca65fe60ab876"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-7.0.39.tgz"
+    sha256 "e20fd3c7f21b27a56a503b23009de3dd045f74d91f81045566586392f6530f2f"
   else
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.37.tgz"
-    sha256 "097af3e0486422fc5a3e2e3365d5f23ac53867a408d8eecfa1103c374a8c96de"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-7.0.39.tgz"
+    sha256 "e084fe767fc0614a99fd5cc4642f51fd46e9b9e55a3b77c0af57362b38300edd"
   end
 
   option "with-enable-test-commands", "Configures MongoDB to allow test commands such as failpoints"

--- a/Formula/mongodb-enterprise@7.0.rb
+++ b/Formula/mongodb-enterprise@7.0.rb
@@ -5,11 +5,11 @@ class MongodbEnterpriseAT70 < Formula
   # frozen_string_literal: true
   #
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-7.0.37.tgz"
-    sha256 "ea30640fd477126efcf1e007d584aa418961c192e6488710e91f994414aff1bf"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-7.0.39.tgz"
+    sha256 "f3c44ac66e6042806a8d595ee8372dc20565334c3bdf2117e4a16a8e5c55855c"
   else
-    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-7.0.37.tgz"
-    sha256 "4ce3a00b434b1b8af7c5d18a06cdb2ed14f0b6d349ea6c3aa64a27da2a706948"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-7.0.39.tgz"
+    sha256 "7471df34746786eb325fd164096b9277976b0c045f6af55d136ec2cc41c18955"
   end
 
   license "MongoDB Customer Agreement"

--- a/Formula/mongodb-mongocryptd@7.0.rb
+++ b/Formula/mongodb-mongocryptd@7.0.rb
@@ -3,8 +3,8 @@ class MongodbMongocryptdAT70 < Formula
   homepage "https://www.mongodb.com/"
 
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-7.0.37.tgz"
-    sha256 "509291f7aa2b21200dd3e373774c8ac5a078c9f5ce6831dd6ba13fe6f3a480f4"
+    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-7.0.39.tgz"
+    sha256 "faa9222a65b242b3bc4c53f3f2a9ab18def7d14dc0815ec48855157aa08fbf9c"
   else
     url "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-arm64-enterprise-7.0.37.tgz"
     sha256 "77a3a7a44a5e491d410641cfc8918adc78756cbe601b64fd73d280e4365b2e77"


### PR DESCRIPTION
Automated update of Homebrew formulae to MongoDB 7.0.39.

Updated formulae:
- `mongodb-community@7.0.rb`
- `mongodb-enterprise@7.0.rb`
- `mongodb-mongocryptd@7.0.rb`