### PR TITLE
Update Homebrew formulae for MongoDB 8.0.28

### DIFF
--- a/Formula/mongodb-community@8.0.rb
+++ b/Formula/mongodb-community@8.0.rb
@@ -5,11 +5,11 @@ class MongodbCommunityAT80 < Formula
   # frozen_string_literal: true
 
   if Hardware::CPU.intel?
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.26.tgz"
-    sha256 "01f41e9dc5e78c9e52ef8c793f4697c1ba1b32616970bd33a695f992a9428c50"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.28.tgz"
+    sha256 "bbba58b577efa669ae5e4fb4105c9b5417c62c23ad817d36e1f06f2d49a09d95"
   else
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.26.tgz"
-    sha256 "49f93af3935632d8ca460584166e07fb7d00fb1c2173544851df453edfdb14a3"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.28.tgz"
+    sha256 "002fa36f45058f2a26e64f4b556f525c120c467c5c1b42c64a54cb7f7c689709"
   end
 
   option "with-enable-test-commands", "Configures MongoDB to allow test commands such as failpoints"

--- a/Formula/mongodb-enterprise@8.0.rb
+++ b/Formula/mongodb-enterprise@8.0.rb
@@ -5,11 +5,11 @@ class MongodbEnterpriseAT80 < Formula
   # frozen_string_literal: true
   #
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-8.0.26.tgz"
-    sha256 "aee2c69bf050086a41938a5b46159f9b6a16bf9bcdcb9f5281d2dcbec9c8ff6c"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-8.0.28.tgz"
+    sha256 "283a98a3e494527c50eba56431aacb9ab2e47ee22f4edfd47597a6f752be65a7"
   else
-    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-8.0.26.tgz"
-    sha256 "4632559e492ceaebcc7776b74f753afe64ad95be8f89edfadf6d85bc31d5c652"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-8.0.28.tgz"
+    sha256 "83918a1567e5eb2324cbf11df5a077dc6cbbe7e93787faf1e2f4b06f2ad19a4b"
   end
 
   license "MongoDB Customer Agreement"

--- a/Formula/mongodb-mongocryptd@8.0.rb
+++ b/Formula/mongodb-mongocryptd@8.0.rb
@@ -3,8 +3,8 @@ class MongodbMongocryptdAT80 < Formula
   homepage "https://www.mongodb.com/"
 
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-8.0.26.tgz"
-    sha256 "64a318af630f1098be07d47c6a8715a8bac852acc3c6dab71e6759c33f0e4f75"
+    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-8.0.28.tgz"
+    sha256 "5b5f931e2069a67eac47ee0618e2f275e3c24a40b7f604e68743c62c351968b0"
   else
     url "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-arm64-enterprise-8.0.26.tgz"
     sha256 "63d74e3fd4a6288f8e9ec70c028a99b9330792d939a1f919d04ae9c56cb867a1"


### PR DESCRIPTION
Automated update of Homebrew formulae to MongoDB 8.0.28.

Updated formulae:
- `mongodb-community@8.0.rb`
- `mongodb-enterprise@8.0.rb`
- `mongodb-mongocryptd@8.0.rb`