### PR TITLE
Update Homebrew formulae for MongoDB 8.3.7

### DIFF
--- a/Formula/mongodb-community.rb
+++ b/Formula/mongodb-community.rb
@@ -5,11 +5,11 @@ class MongodbCommunity < Formula
   # frozen_string_literal: true
 
   if Hardware::CPU.intel?
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.3.4.tgz"
-    sha256 "a3090f08980a884f16793c8fa3bc58f501c47e5ab756b65f07b5051b487ed66e"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.3.7.tgz"
+    sha256 "13a799c6c387fd63077108623b949f387b563aacdeda5650e2df640b1ed8a791"
   else
-    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.3.4.tgz"
-    sha256 "ef2487f688c6fa544a97b6aed63d939fd664de80781b250ad84a523cc5604273"
+    url "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.3.7.tgz"
+    sha256 "cb591851b18c9fc72163b656f782264f67a4119881e1204af2d8fec645ee48a4"
   end
 
   option "with-enable-test-commands", "Configures MongoDB to allow test commands such as failpoints"

--- a/Formula/mongodb-enterprise.rb
+++ b/Formula/mongodb-enterprise.rb
@@ -5,11 +5,11 @@ class MongodbEnterprise < Formula
   # frozen_string_literal: true
   #
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-8.3.4.tgz"
-    sha256 "2db468646e157902402c55908f6b9f31e37b034a2d5a496771cb3857eb1f29f9"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-8.3.7.tgz"
+    sha256 "bd8311e694b7f4a1434ced38b83772122708629ae3057bc6d538313d8981162e"
   else
-    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-8.3.4.tgz"
-    sha256 "070ef66bcf4904a0257fd8d0b9ac87901f1f99af5df80026a3eb494e012c1422"
+    url "https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-8.3.7.tgz"
+    sha256 "ba13fbd474d56e4a07cb66e5740392d642afb4f19560b4765396115ce0f48dd8"
   end
 
   license "MongoDB Customer Agreement"

--- a/Formula/mongodb-mongocryptd.rb
+++ b/Formula/mongodb-mongocryptd.rb
@@ -3,11 +3,11 @@ class MongodbMongocryptd < Formula
   homepage "https://www.mongodb.com/"
 
   if Hardware::CPU.intel?
-    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-8.3.4.tgz"
-    sha256 "df8b2ae83fa45dde09206714d85bd53261d4879bee4d10932c2567029c546b02"
+    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-x86_64-enterprise-8.3.7.tgz"
+    sha256 "98294749fd235f318751fb3d9dc76b69b3bf57bf66b93a07f76e560b4e75f485"
   else
-    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-arm64-enterprise-8.3.4.tgz"
-    sha256 "0560f860863a5250433ab5942ca46d97d743a824409b1daeed7f44840d92ed3a"
+    url "https://downloads.mongodb.com/osx/mongodb-cryptd-macos-arm64-enterprise-8.3.7.tgz"
+    sha256 "1a99fa8c41ddb5fbe61bae41f81ff46d32c9c5c0e86a9a54a3b8841d012b1f38"
   end
   license "MongoDB Customer Agreement"
 


### PR DESCRIPTION
Automated update of Homebrew formulae to MongoDB 8.3.7.

Updated formulae:
- `mongodb-community.rb`
- `mongodb-enterprise.rb`
- `mongodb-mongocryptd.rb`